### PR TITLE
DynFib always returns safely

### DIFF
--- a/src/dynamicFib.c
+++ b/src/dynamicFib.c
@@ -11,6 +11,8 @@
  */
 long DynFib(int n)
 {
+    if (n <= 2)
+        return 1;
     long array[n - 1];
     array[0] = 1; // Basevalue for fibonacci 1 = 1
     array[1] = 1; // Basevalue for fibonacci 2 = 1


### PR DESCRIPTION
1 is a legitimate argument to DynFib(), but right now it would cause a stack smashing.